### PR TITLE
fix(lib/reloader): support neovim 0.9

### DIFF
--- a/lua/neopywal/lib/reloader.lua
+++ b/lua/neopywal/lib/reloader.lua
@@ -18,7 +18,15 @@ function M.init()
     })
 
     ---@diagnostic disable-next-line: undefined-field
-    local event = vim.uv.new_fs_event()
+    local event
+    -- luv binding in 0.9
+    if vim.loop then
+        event = vim.loop.new_fs_event()
+    end
+    -- luv binding from 0.10 onwards
+    if vim.uv then
+        event = vim.uv.new_fs_event()
+    end
     local bg = vim.o.background
     local template_path = Palette.options.use_palette[bg]
     event:start(template_path, {


### PR DESCRIPTION
when support for reloading was added in https://github.com/RedsXDD/neopywal.nvim/commit/dc5cad28c2ba53ebdb6dd5d4fc4a855cf8868168 it only considered the API for neovim 0.10 when neovim 0.9 was perfectly capable of doing the reloading altho the api module name was different.

hopefully debian has an easier time packaging neovim 0.11 than they had with neovim 0.10 and more distros start providing at least neovim 0.10